### PR TITLE
Syntax fix in nodes.py

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -5,7 +5,7 @@ import comfy.model_management as mm
 from PIL import Image
 import folder_paths
 from pathlib import Path
-from .transformers import AutoProcessor, Gemma3ForConditionalGeneration
+from transformers import AutoProcessor, Gemma3ForConditionalGeneration
 
 
 def tensor2pil(image):


### PR DESCRIPTION
Correction to solve an error preventing loading of node when importing transformers. Cause was an extra dot between "from" and "transformers" in line 8 of Nodes.py.